### PR TITLE
Add stack id metadata to the server.

### DIFF
--- a/ansible-tower.yaml
+++ b/ansible-tower.yaml
@@ -85,6 +85,8 @@ resources:
       flavor: { get_param: flavor }
       image: Ubuntu 12.04 LTS (Precise Pangolin)
       name: { get_param: server_name }
+      metadata:
+        rax-heat: { get_param: "OS::stack_id" }
       user_data:
         str_replace:
           template: |


### PR DESCRIPTION
As a temporary work-around until Heat has a solution for automatically adding metadata to stack resources, adding this metadata to the supported templates.
